### PR TITLE
Update Generator.php

### DIFF
--- a/GameEngine/Generator.php
+++ b/GameEngine/Generator.php
@@ -9,7 +9,7 @@
 ##                                                                             ##
 #################################################################################
 
-class Generator {
+class MyGenerator {
 	
 	public function generateRandID(){
 		return md5($this->generateRandStr(16));
@@ -152,4 +152,4 @@ class Generator {
 	}
 	
 };
-$generator = new Generator;
+$generator = new MyGenerator;


### PR DESCRIPTION
Changed name of class Generator to MyGenerator because Generator is a keyword in PHP 5.5 and causes a conflict leading to fatal error.
